### PR TITLE
Electron Depth Fix

### DIFF
--- a/dragons/meraxes/reion.py
+++ b/dragons/meraxes/reion.py
@@ -88,10 +88,7 @@ def electron_optical_depth(fname, volume_weighted=False):
         """This is d/dz scattering depth for redshifts covered by the run.
         """
         prefac = cosmo_factor(z)
-        if z <= 4:
-            return (prefac * (density_H*xHII + 2*density_He*xHII)).decompose()
-        else:
-            return (prefac * (density_H*xHII + density_He*xHII)).decompose()
+        return (prefac * (density_H*xHII + (1 + (z<=4))*density_He*xHII)).decompose()
         
     post_sim_contrib = integrate.quad(d_te_postsim, 0, z_list[0])[0]
 


### PR DESCRIPTION
I've made two changes to dragons.meraxes.reion.electron_optical_depth:

Firstly, I've set the function to read the mass-weighted grids in directly, rather than performing the mass weighting by reading in the grids. This Improves the speed.

Secondly, I have fixed a bug that did not count the electron optical depth due to HeII reionisation between z=4 and the end of the simulation, if there were snapshots after z=4. The code is now in-line with our assumption of HeII reionisation at z=4.

If there were snapshots down to z=1.8, this now results in an increase of 0.001 in the electron optical depth. Note that this does not affect most previous runs, unless they output the global fraction post-reionisation, later than z=4.

The below plot shows a comparison between the master branch ("old") and this change ("new") on the same run of meraxes, where the neutral fraction is output down to z=1.8.

![tau_compare](https://user-images.githubusercontent.com/36873665/39030523-cebe641c-44a5-11e8-8979-b2f2bc5bfbe1.png)